### PR TITLE
Throw x_out_of_bounds exception instead of exiting

### DIFF
--- a/Code/SplineSrc/Spline.cpp
+++ b/Code/SplineSrc/Spline.cpp
@@ -88,7 +88,7 @@ void Spline<dim>::computeCoefficients(std::vector<double>& y, std::vector<double
   c_.clear();
   if (!c_.empty()) {
     std::cout << " Should be empty!!!\n"; 
-    exit(EXIT_FAILURE);
+    exit(EXIT_FAILURE); //TODO remove this
   }
   int sizeOfC = 1;
   for (int i = 0; i < dim; ++i)
@@ -142,8 +142,7 @@ double Spline<dim>::getValue(const std::vector<double>& x) const {
   std::vector<int> l(dim);
   std::vector<int> m(dim);
   if (!checkValues(x)) {
-    std::cout << "Values x are out of boundaries\n";
-    exit(EXIT_FAILURE);
+    throw x_out_of_bounds();
   }
   
   
@@ -202,8 +201,7 @@ double Spline<dim>::getFirstDerivative(const std::vector<double>& x, const int d
   std::vector<int> l(dim);
   std::vector<int> m(dim);
   if (!checkValues(x)) {
-    std::cout << "Values x are out of boundaries\n";
-    exit(EXIT_FAILURE);
+    throw x_out_of_bounds();
   }
   
   computeInterval(l, m, x);
@@ -380,8 +378,7 @@ double Spline<1>::getValue(const double x) const {
   int l, m;
   double evaluatedValue = 0;
   if ( (x < a_) || (x > b_) ) {
-    std::cout << "Value " << x << " out of boundaries\n";
-    exit(EXIT_FAILURE);
+    throw x_out_of_bounds();
   }
   computeInterval(l, m, x);
   for (int i = l; i <=m; ++i) {
@@ -394,8 +391,7 @@ double Spline<1>::getFirstDerivative(const double x) {
   int l, m;
   double evaluatedValue = 0;
   if ( (x < a_) || (x > b_) ) {
-    std::cout << "Value " << x << " out of boundaries\n";
-    exit(EXIT_FAILURE);
+    throw x_out_of_bounds();
   }
   
   computeInterval(l, m, x);

--- a/Code/SplineSrc/Spline.h
+++ b/Code/SplineSrc/Spline.h
@@ -23,8 +23,21 @@
 
 
 #include <vector>
+#include <exception>
 
 #include "SplineBasisFunction.h"
+
+namespace mcbs {
+
+
+class x_out_of_bounds: public std::exception
+{
+public:
+  virtual const char* what() const throw()
+  {
+    return "Values x are out of boundaries";
+  }
+};
 
 template <int dim>
 class Spline; 


### PR DESCRIPTION
This should allow users to decide how to handle situations when input values are out of bounds
